### PR TITLE
Add offline mode (fallback to env)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,12 @@ then simply copy and paste:
 Once help tags have been generated, you can view the manual with
 `:help classpath`.
 
+By default when opening files the dependencies in `project.clj` and `pom.xml`
+are downloaded which can be a security risk as well as leading to a hang when
+the repositories are not reachable.
+To prevent this add `let g:classpath_offline = 1` to your `vimrc`.
+In this case the plugin falls back to `$CLASSPATH`.
+
 ## FAQ
 
 > Why does it take so long for Vim to startup?

--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -6,6 +6,10 @@ if exists("g:autoloaded_classpath")
 endif
 let g:autoloaded_classpath = 1
 
+if !exists('g:classpath_offline')
+  let g:classpath_offline = 0
+endif
+
 if !exists('g:classpath_cache')
   let g:classpath_cache = '~/.cache/vim/classpath'
 endif
@@ -57,6 +61,11 @@ function! classpath#detect(...) abort
 
   let buffer = a:0 ? a:1 : '%'
   let default = $CLASSPATH ==# '' ? ',' : classpath#to_vim($CLASSPATH)
+
+  if g:classpath_offline
+    return default
+  fi
+
   let root = getbufvar(buffer, 'java_root')
   if root ==# ''
     let root = simplify(fnamemodify(bufname(buffer), ':p:s?[\/]$??'))

--- a/doc/classpath.txt
+++ b/doc/classpath.txt
@@ -16,4 +16,15 @@ or Leiningen for the class path.  If neither is available, $CLASSPATH is used.
 :Java [args]            Execute $JAVA_CMD (default: java) with a class path
                         derived from the current buffer's path.
 
+OFFLINE MODE                                    *g:classpath_offline*
+
+By default when opening files the dependencies in 'project.clj' and 'pom.xml'
+are downloaded which can be a security risk as well as leading to a hang when
+the repositories are not reachable.
+To prevent this add the following to your vimrc: >
+
+    let g:classpath_offline = 1
+
+In this case the plugin falls back to `$CLASSPATH`.
+
  vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
I tried to add an offline mode using `-o` (as suggested in https://github.com/tpope/vim-classpath/issues/6 ), however lein respected it only for the stuff from the maven repos while still downloading from clojars.
Also maven's dependency plugin outputted a lot of error messages with `-o`.
So I opted for defaulting to the fallback (`$CLASSPATH`).

Ideally this should be done in a more flexible way (e.g. falling back on cache, adding a command for updating the classpath, detecting when you are offline, etc.).
