### PR TITLE
Restore trailing space after lcd, tcd, cd commands in classpath#detect

### DIFF
--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -125,7 +125,7 @@ function! classpath#detect(...) abort
       if &verbose
         echomsg 'Determining class path with '.cmd.' ...'
       endif
-      let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : exists(':tcd') && haslocaldir(-1) ? 'tcd' : 'cd'
+      let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : exists(':tcd') && haslocaldir(-1) ? 'tcd ' : 'cd '
       let dir = getcwd()
       try
         execute cd . fnameescape(root)


### PR DESCRIPTION
I just found that commit 34d4cdf (Jun 22) introduced a bug into the classpath#detect function.

The 'cd' variable requires a trailing space to be processed correctly by the shell, but this space was removed by the commit when the assignment statement was last changed.

I fixed it by restoring the trailing space.