### PR TITLE
Add refresh flag argument to classpath#detect

### DIFF
--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -62,6 +62,7 @@ function! classpath#detect(...) abort
   let sep = classpath#file_separator()
 
   let buffer = a:0 ? a:1 : '%'
+  let refresh = a:0 >= 2 ? a:2 : 0
   let default = $CLASSPATH ==# '' ? ',' : classpath#to_vim($CLASSPATH)
   let root = getbufvar(buffer, 'java_root')
   if root ==# ''
@@ -118,10 +119,13 @@ function! classpath#detect(...) abort
   let cache = expand(g:classpath_cache . '/') . substitute(root, '[:\/]', '%', 'g')
   let disk = getftime(root . sep . file)
 
-  if getftime(cache) >= disk
+  if getftime(cache) >= disk && !refresh
     return join(readfile(cache), classpath#separator())
   else
     try
+      if refresh
+        echomsg 'Refreshing classpath ...'
+      endif
       if &verbose
         echomsg 'Determining class path with '.cmd.' ...'
       endif

--- a/autoload/classpath.vim
+++ b/autoload/classpath.vim
@@ -123,9 +123,6 @@ function! classpath#detect(...) abort
     return join(readfile(cache), classpath#separator())
   else
     try
-      if refresh
-        echomsg 'Refreshing classpath ...'
-      endif
       if &verbose
         echomsg 'Determining class path with '.cmd.' ...'
       endif


### PR DESCRIPTION
I use this plugin to work on large sets of interrelated Java projects built by Maven, where there are many dependent as well as inherited projects with their own POM files.  The many Maven projects and indirect dependencies result in enormous classpaths, which would not be possible to support in vim without something like vim-classpath to calculate them.  However, the classpath of any given project often changes because of changes in the lower-level project dependencies and snapshot versions, without any change to that project's POM file.  Therefore, the expiring of the entries in the vim-classpath cache that is currently based on local POM file changes does not work for me.

To manage this, I tweaked the classpath#detect function to add a second optional 'refresh' flag argument (default: 0) that forces a classpath refresh, and mapped the use of this argument to a command in my vimrc file.  Then, I can simply run a :RefreshCP command in vim to re-calculate the current file's classpath routinely or when I see problems.  For me, this is much more practical than expecting vim to automatically keep up with the changes.

The line in my vimrc file to use the feature is:

autocmd BufEnter *.java,*.jsp command! -buffer RefreshCP execute '!'.classpath#detect('%', 1)

(I am working only with Java and don't need to worry about the other JVM-based languages such Clojure, Scala, and so on.)

I only hacked this change recently and it may not be suitable for general use (I have very little experience with vim scripting), but please consider a feature like this for the plugin.
